### PR TITLE
Version 1.1.3 - update APIs versions to support python version > 3.8

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,3 +5,10 @@ Changes in Version 1.1.0
 ------------------------
 
 * Created the open source version of the client package
+
+Changes in Version 1.1.3
+------------------------
+
+* Adding the following updates to support python version > 3.8:
+* Update paramiko to version 3.5.0
+* Replace deprecated function getchildren() with list (Per this tutorial: https://docs.python.org/2/library/xml.etree.elementtree.html#element-objects)

--- a/pysvc/__init__.py
+++ b/pysvc/__init__.py
@@ -21,7 +21,7 @@ IBM SVC CLI Client Module
 """
 PYSVC_DEFAULT_LOGGER = "pysvc"
 
-version_tuple = (1, 1, 2)
+version_tuple = (1, 1, 3)
 
 
 def get_version_string():

--- a/pysvc/unified/clispec.py
+++ b/pysvc/unified/clispec.py
@@ -538,7 +538,7 @@ def escape_shell_arg(data):
 
 
 def etree_iterchildren(element, tag=None):
-    for ch in element.getchildren():
+    for ch in list(element):
         if tag and tag == ch.tag:
             yield ch
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 munch==2.3.2
-paramiko==2.6.0
+paramiko==3.5.0


### PR DESCRIPTION
Changes in Version 1.1.3
------------------------

* Adding the following updates to support python version > 3.8:
* Update paramiko to version 3.5.0
* Replace deprecated function getchildren() with list (Per this tutorial: https://docs.python.org/2/library/xml.etree.elementtree.html#element-objects)